### PR TITLE
fix crash because unregisterStep called after component unmounted

### DIFF
--- a/src/hocs/copilot.js
+++ b/src/hocs/copilot.js
@@ -78,6 +78,8 @@ const copilot = ({
 
       startTries = 0;
 
+      mounted = false;
+
       eventEmitter = mitt();
 
       isFirstStep = (): boolean => this.state.currentStep === this.getFirstStep();
@@ -94,6 +96,9 @@ const copilot = ({
       }
 
       unregisterStep = (stepName: string): void => {
+        if (!this.mounted) {
+          return;
+        }
         this.setState(({ steps }) => ({
           steps: Object.entries(steps)
             .filter(([key]) => key !== stepName)
@@ -148,6 +153,15 @@ const copilot = ({
           top: size.y - (OFFSET_WIDTH / 2),
         });
       }
+
+      componentDidMount() {
+        this.mounted = true;
+      }
+
+      componentWillUnmount() {
+        console.log('componentWillUnmount method')
+        this.mounted = false;
+      };
 
       render() {
         return (


### PR DESCRIPTION
Hello @okgrow, 
Thanks for this awesome library. It helps me a lot.
I found a bug that the method unregisterStep called after component unmounted and it makes a crash after the app closed.  I provide a screenshot for further investigation and I fixed this bug but feel free to discuss with me for the better solution.

Regards

![screen shot 2018-05-28 at 12 19 51](https://user-images.githubusercontent.com/20050523/40598622-080ea69c-6273-11e8-8892-5a81e5eee02a.png)





