### PR TITLE
add unregisterStep function to WrappedComponent

### DIFF
--- a/src/hocs/copilot.js
+++ b/src/hocs/copilot.js
@@ -170,6 +170,7 @@ const copilot = ({
               {...this.props}
               start={this.start}
               currentStep={this.state.currentStep}
+              unregisterStep={this.unregisterStep}
               visible={this.state.visible}
               copilotEvents={this.eventEmitter}
             />


### PR DESCRIPTION
with this it is possible to delete steps by the WrappedComponent

`this.props.unregisterStep('step_name');`