### PR TITLE
Provide callback for when copilot session ends

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,9 @@ class HomeScreen {
 ```
 
 ### Triggering the tutorial
-Use `this.props.start()` in the root component in order to trigger the tutorial. You can either invoke it with a touch event or in `componentDidMount`. Note that the component and all its descendants must be mounted before starting the tutorial since the `CopilotStep`s need to be registered first.
+Use `this.props.start(fromStep, onStop)` in the root component in order to trigger the tutorial. You can either invoke it with a touch event or in `componentDidMount`. Note that the component and all its descendants must be mounted before starting the tutorial since the `CopilotStep`s need to be registered first.
+
+The `onStop` method will be called after a user selects 'Skip' or 'Finish' buttion in the tooltip.
 
 ## Contributing
 Issues and Pull Requests are always welcome.

--- a/src/hocs/copilot.js
+++ b/src/hocs/copilot.js
@@ -86,6 +86,7 @@ const copilot = ({
       });
 
       startTries = 0;
+      onStop = null;
 
       mounted = false;
 
@@ -123,7 +124,7 @@ const copilot = ({
         await this.setCurrentStep(this.getPrevStep());
       }
 
-      start = async (fromStep?: string): void => {
+      start = async (fromStep?: string, onStop?: () => void): void => {
         const { steps } = this.state;
 
         const currentStep = fromStep
@@ -145,11 +146,17 @@ const copilot = ({
           await this.setVisibility(true);
           this.startTries = 0;
         }
+
+        this.onStop = onStop;
       }
 
       stop = async (): void => {
         await this.setVisibility(false);
         this.eventEmitter.emit('stop');
+
+        if (this.onStop != null) {
+          this.onStop();
+        }
       }
 
       async moveToCurrentStep(): void {


### PR DESCRIPTION
## Summary
- It closes #44.
- Currently, there is no way a developer gets notified when a copilot session ends. This simple PR adds a second parameter to `this.props.start()` in order to run an additional logic after the copilot session finishes.
- The 'Skip' and 'Finish' in tooltip, both calls `this.props.stop()` method, so I added the relevant logic there.

## Motivation
- This feature will be specifically useful when a copilot intervenes in the middle of user's job (for example, music or video play). After the copilot, we can resume the user's task which provides more user-friendly experience.

