### PR TITLE
Fix unnecessary `this.reset()` call in the life cycle method

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,9 +176,7 @@ class HomeScreen {
 ```
 
 ### Triggering the tutorial
-Use `this.props.start(fromStep, onStop)` in the root component in order to trigger the tutorial. You can either invoke it with a touch event or in `componentDidMount`. Note that the component and all its descendants must be mounted before starting the tutorial since the `CopilotStep`s need to be registered first.
-
-The `onStop` method will be called after a user selects 'Skip' or 'Finish' buttion in the tooltip.
+Use `this.props.start()` in the root component in order to trigger the tutorial. You can either invoke it with a touch event or in `componentDidMount`. Note that the component and all its descendants must be mounted before starting the tutorial since the `CopilotStep`s need to be registered first.
 
 ### Listening to the events
 Along with `this.props.start()`, `copilot` HOC passes `copilotEvents` function to the component to help you with tracking of tutorial progress. It utilizes [mitt](https://github.com/developit/mitt) under the hood, you can see how full API there.

--- a/src/hocs/copilot.js
+++ b/src/hocs/copilot.js
@@ -87,7 +87,6 @@ const copilot = ({
       });
 
       startTries = 0;
-      onStop = null;
 
       mounted = false;
 
@@ -125,7 +124,7 @@ const copilot = ({
         await this.setCurrentStep(this.getPrevStep());
       }
 
-      start = async (fromStep?: string, onStop?: () => void): void => {
+      start = async (fromStep?: string): void => {
         const { steps } = this.state;
 
         const currentStep = fromStep
@@ -147,17 +146,11 @@ const copilot = ({
           await this.setVisibility(true);
           this.startTries = 0;
         }
-
-        this.onStop = onStop;
       }
 
       stop = async (): void => {
         await this.setVisibility(false);
         this.eventEmitter.emit('stop');
-
-        if (this.onStop != null) {
-          this.onStop();
-        }
       }
 
       async moveToCurrentStep(): void {


### PR DESCRIPTION
## Summary
- This PR resolves the occasional bug where the copilot.start() does not make the overlay visible. We got reported this from many Android users and now disappeared after tens of tests. Before this PR, we are experiencing this issue almost 20~30% users, not 0%.
- Earlier, if `componentWillReceiveProps` gets called before the overlay becomes visible, then the states are all reset against our intention.

## Special Thanks
- This was co-programmed with @ghsdh3409. We tested this PR both on iOS and Android and worked well.