### PR TITLE
Add onPress support in the middle of steps

### DIFF
--- a/src/components/ViewMask.js
+++ b/src/components/ViewMask.js
@@ -1,10 +1,10 @@
 // @flow
 import React, { Component } from 'react';
-
-import { View, Animated, I18nManager } from 'react-native';
+import PropTypes from 'prop-types';
+import { View, Animated, I18nManager, TouchableOpacity } from 'react-native';
 import styles from './style';
 
-import type { valueXY } from '../types';
+import type { CopilotContext, valueXY } from '../types';
 
 
 const rtl = I18nManager.isRTL;
@@ -31,6 +31,10 @@ type State = {
 };
 
 class ViewMask extends Component<Props, State> {
+  static contextTypes = {
+    _copilot: PropTypes.object,
+  }
+
   state = {
     size: new Animated.ValueXY({ x: 0, y: 0 }),
     position: new Animated.ValueXY({ x: 0, y: 0 }),
@@ -40,6 +44,10 @@ class ViewMask extends Component<Props, State> {
     if (this.props.position !== nextProps.position || this.props.size !== nextProps.size) {
       this.animate(nextProps.size, nextProps.position);
     }
+  }
+
+  context: {
+    _copilot: CopilotContext,
   }
 
   animate = (size: valueXY = this.props.size, position: valueXY = this.props.position): void => {
@@ -112,6 +120,17 @@ class ViewMask extends Component<Props, State> {
               [end]: verticalOverlayRightBoundary,
             },
           ]}
+        />
+        <TouchableOpacity
+          style={{
+            backgroundColor: 'transparent',
+            [start]: this.props.position.x,
+            [end]: (this.props.layout.width - (this.props.size.x + this.props.position.x)),
+            top: this.props.position.y,
+            width: this.props.size.x,
+            height: this.props.size.y,
+          }}
+          onPress={this.context._copilot.getCurrentStep().target.props.children.props.onPress || null}
         />
       </View>
     );

--- a/src/components/ViewMask.js
+++ b/src/components/ViewMask.js
@@ -1,10 +1,15 @@
 // @flow
 import React, { Component } from 'react';
 
-import { View, Animated } from 'react-native';
+import { View, Animated, I18nManager } from 'react-native';
 import styles from './style';
 
 import type { valueXY } from '../types';
+
+
+const rtl = I18nManager.isRTL;
+const start = rtl ? 'right' : 'left';
+const end = rtl ? 'left' : 'right';
 
 type Props = {
   size: valueXY,
@@ -78,14 +83,14 @@ class ViewMask extends Component<Props, State> {
           style={[
             styles.overlayRectangle,
             {
-              right: leftOverlayRight,
+              [end]: leftOverlayRight,
             }]}
         />
         <Animated.View
           style={[
             styles.overlayRectangle,
             {
-              left: rightOverlayLeft,
+              [start]: rightOverlayLeft,
             }]}
         />
         <Animated.View
@@ -93,8 +98,8 @@ class ViewMask extends Component<Props, State> {
             styles.overlayRectangle,
             {
               top: bottomOverlayTopBoundary,
-              left: verticalOverlayLeftBoundary,
-              right: verticalOverlayRightBoundary,
+              [start]: verticalOverlayLeftBoundary,
+              [end]: verticalOverlayRightBoundary,
             },
           ]}
         />
@@ -103,8 +108,8 @@ class ViewMask extends Component<Props, State> {
             styles.overlayRectangle,
             {
               bottom: topOverlayBottomBoundary,
-              left: verticalOverlayLeftBoundary,
-              right: verticalOverlayRightBoundary,
+              [start]: verticalOverlayLeftBoundary,
+              [end]: verticalOverlayRightBoundary,
             },
           ]}
         />


### PR DESCRIPTION
This PR only works with copilot with `overlay: 'view'`.
This is how we can use it:
```
const CopilotTouchableOpacity = walkthroughable(TouchableOpacity)
...
<CopilotStep text="some text" order={1} name="someName">
  <CopilotTouchableOpacity
    onPress={someFunction}
  >
    ...
  </CopilotTouchableOpacity>
</CopilotStep>
```

**note:**
_since I think RTL is a must have, I've not made a new branch from `master` but this a branch from `rtl` branch I sent for you yesterday._