### PR TITLE
Adds support for landscape

### DIFF
--- a/src/components/CopilotModal.js
+++ b/src/components/CopilotModal.js
@@ -285,6 +285,7 @@ class CopilotModal extends Component<Props, State> {
         visible={containerVisible}
         onRequestClose={noop}
         transparent
+        supportedOrientations={['portrait', 'landscape']}
       >
         <View
           style={styles.container}


### PR DESCRIPTION
There is an issue with the react native modal component that causes landscape apps to show a portrait modal.  Adding this line fixes the issue.