### PR TITLE
Adds ability to customise overlay color

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ You can specify the overlay when applying the `copilot` HOC:
 copilot({
   overlay: 'svg', // or 'view'
   animated: true, // or false
+  overlayColor: 'rgba(0,0,0,0.7)', // String - default is 'rgba(0,0,0,0.4)'
 })(RootComponent);
 ```
 

--- a/src/components/CopilotModal.js
+++ b/src/components/CopilotModal.js
@@ -20,6 +20,7 @@ type Props = {
   stepNumberComponent: ?React$Component,
   overlay: 'svg' | 'view',
   animated: boolean,
+  overlayColor: string,
   androidStatusBarVisible: boolean,
 };
 
@@ -46,6 +47,8 @@ class CopilotModal extends Component<Props, State> {
     overlay: typeof NativeModules.RNSVGSvgViewManager !== 'undefined' ? 'svg' : 'view',
     // If animated was not specified, rely on the default overlay type
     animated: typeof NativeModules.RNSVGSvgViewManager !== 'undefined',
+
+    overlayColor: 'rgba(0,0,0,0.4)',
     androidStatusBarVisible: false,
   };
 
@@ -233,6 +236,7 @@ class CopilotModal extends Component<Props, State> {
         position={this.state.position}
         easing={this.props.easing}
         animationDuration={this.props.animationDuration}
+        overlayColor={this.props.overlayColor}
       />
     );
   }

--- a/src/components/SvgMask.js
+++ b/src/components/SvgMask.js
@@ -22,6 +22,7 @@ type Props = {
   easing: func,
   animationDuration: number,
   animated: boolean,
+  overlayColor: string,
 };
 
 type State = {
@@ -94,15 +95,16 @@ class SvgMask extends Component<Props, State> {
   }
 
   render() {
+    const { overlayColor, style } = this.props;
     return (
-      <View pointerEvents="box-none" style={this.props.style} onLayout={this.handleLayout}>
+      <View pointerEvents="box-none" style={style} onLayout={this.handleLayout}>
         {
           this.state.canvasSize
             ? (
               <Svg pointerEvents="none" width={this.state.canvasSize.x} height={this.state.canvasSize.y}>
                 <AnimatedSvgPath
                   ref={(ref) => { this.mask = ref; }}
-                  fill="rgba(0, 0, 0, 0.4)"
+                  fill={overlayColor}
                   fillRule="evenodd"
                   strokeWidth={1}
                   d={path(this.state.size, this.state.position, this.state.canvasSize)}

--- a/src/components/ViewMask.js
+++ b/src/components/ViewMask.js
@@ -17,6 +17,7 @@ type Props = {
   easing: func,
   animationDuration: number,
   animated: boolean,
+  overlayColor: string,
 };
 
 type State = {
@@ -60,6 +61,7 @@ class ViewMask extends Component<Props, State> {
 
   render() {
     const { size, position } = this.state;
+    const { overlayColor, style } = this.props;
     const width = this.props.layout ? this.props.layout.width : 500;
     const height = this.props.layout ? this.props.layout.height : 500;
 
@@ -73,12 +75,13 @@ class ViewMask extends Component<Props, State> {
     );
 
     return (
-      <View style={this.props.style}>
+      <View style={style}>
         <Animated.View
           style={[
             styles.overlayRectangle,
             {
               right: leftOverlayRight,
+              backgroundColor: overlayColor,
             }]}
         />
         <Animated.View
@@ -86,6 +89,7 @@ class ViewMask extends Component<Props, State> {
             styles.overlayRectangle,
             {
               left: rightOverlayLeft,
+              backgroundColor: overlayColor,
             }]}
         />
         <Animated.View
@@ -95,6 +99,7 @@ class ViewMask extends Component<Props, State> {
               top: bottomOverlayTopBoundary,
               left: verticalOverlayLeftBoundary,
               right: verticalOverlayRightBoundary,
+              backgroundColor: overlayColor,
             },
           ]}
         />
@@ -105,6 +110,7 @@ class ViewMask extends Component<Props, State> {
               bottom: topOverlayBottomBoundary,
               left: verticalOverlayLeftBoundary,
               right: verticalOverlayRightBoundary,
+              backgroundColor: overlayColor,
             },
           ]}
         />

--- a/src/components/style.js
+++ b/src/components/style.js
@@ -70,7 +70,6 @@ export default StyleSheet.create({
   },
   overlayRectangle: {
     position: 'absolute',
-    backgroundColor: 'rgba(0,0,0,0.2)',
     left: 0,
     top: 0,
     bottom: 0,

--- a/src/hocs/copilot.js
+++ b/src/hocs/copilot.js
@@ -32,6 +32,7 @@ const copilot = ({
   tooltipComponent,
   stepNumberComponent,
   animated,
+  overlayColor,
   androidStatusBarVisible,
 } = {}) =>
   (WrappedComponent) => {
@@ -187,6 +188,7 @@ const copilot = ({
               tooltipComponent={tooltipComponent}
               overlay={overlay}
               animated={animated}
+              overlayColor={overlayColor}
               androidStatusBarVisible={androidStatusBarVisible}
               ref={(modal) => { this.modal = modal; }}
             />


### PR DESCRIPTION
This adds the ability to change the overlay color and sets a default to 'rgba(0,0,0,0.4)' if not specified.

I have tested on an expo based app and it works fine with both 'view' and 'svg' based overlays.

