### PR TITLE
Vertical position fine-tuning support

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,15 @@ class HomeScreen {
 }
 ```
 
+### Adjust vertical position
+In order to adjust vertical position pass `verticalOffset` to the `copilot` HOC.
+
+```js
+copilot({
+  verticalOffset: 36,
+})(RootComponent)
+``` 
+
 ### Triggering the tutorial
 Use `this.props.start()` in the root component in order to trigger the tutorial. You can either invoke it with a touch event or in `componentDidMount`. Note that the component and all its descendants must be mounted before starting the tutorial since the `CopilotStep`s need to be registered first.
 

--- a/src/hocs/copilot.js
+++ b/src/hocs/copilot.js
@@ -35,6 +35,7 @@ const copilot = ({
   animated,
   androidStatusBarVisible,
   backdropColor,
+  verticalOffset = 0,
 } = {}) =>
   (WrappedComponent) => {
     class Copilot extends Component<any, State> {
@@ -162,7 +163,7 @@ const copilot = ({
           width: size.width + OFFSET_WIDTH,
           height: size.height + OFFSET_WIDTH,
           left: size.x - (OFFSET_WIDTH / 2),
-          top: size.y - (OFFSET_WIDTH / 2),
+          top: size.y - (OFFSET_WIDTH / 2) + verticalOffset,
         });
       }
 


### PR DESCRIPTION
When the plugin is used with 3rd party navigation/UI plugins (react-native-navigation v2 and native-base in my case), the vertical position of the overlay and tooltip is incorrect. This PR adds support for vertical position fine-tuning by introducing verticalOffset property that can be passed to the copilot hoc.