### PR TITLE
crash fix - check for this.wrapper before this.wrapper.measure

### DIFF
--- a/src/components/ConnectedCopilotStep.js
+++ b/src/components/ConnectedCopilotStep.js
@@ -65,7 +65,7 @@ class ConnectedCopilotStep extends Component<Props> {
     return new Promise((resolve, reject) => {
       const measure = () => {
         // Wait until the wrapper element appears
-        if (this.wrapper.measure) {
+        if (this.wrapper && this.wrapper.measure) {
           this.wrapper.measure(
             (ox, oy, width, height, x, y) => resolve({
               x, y, width, height,


### PR DESCRIPTION
We have gotten crashes `RCTFatalException: Unhandled JS Exception: null is not an object (evaluating 'e.wrapper.measure')` so we added a check for this.wrapper in addition to this.wrapper.measure