### PR TITLE
fix: prevent Modal from breaking with useAnimatedStyle

### DIFF
--- a/src/components/CopilotModal.tsx
+++ b/src/components/CopilotModal.tsx
@@ -290,18 +290,20 @@ export const CopilotModal = forwardRef<CopilotModalHandle, Props>(
     }
 
     return (
-      <Modal
-        animationType="none"
-        visible
-        onRequestClose={noop}
-        transparent
-        supportedOrientations={["portrait", "landscape"]}
-      >
-        <View style={styles.container} onLayout={handleLayoutChange}>
-          {contentVisible && renderMask()}
-          {contentVisible && renderTooltip()}
-        </View>
-      </Modal>
+      <View>
+        <Modal
+          animationType="none"
+          visible
+          onRequestClose={noop}
+          transparent
+          supportedOrientations={["portrait", "landscape"]}
+        >
+          <View style={styles.container} onLayout={handleLayoutChange}>
+            {contentVisible && renderMask()}
+            {contentVisible && renderTooltip()}
+          </View>
+        </Modal>
+      </View>
     );
 
     function renderMask() {


### PR DESCRIPTION
Fixes an issue where using `useAnimatedStyle` within a `Modal` component in React Native caused it to break.

Issue: [software-mansion/react-native-reanimated#6659](https://github.com/software-mansion/react-native-reanimated/issues/6659)